### PR TITLE
[feat]: implement is_* methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,5 +277,5 @@ else:
 - [ ] weeksToDays
 - [ ] yearsToMonths
 - [ ] yearsToQuarters
-  <!-- /methods -->
-      </details>
+    <!-- /methods -->
+  </details>

--- a/README.md
+++ b/README.md
@@ -1,19 +1,38 @@
-# A Sensible Python Date Library
+# pydate-fns
+
+## A sensible Python date library
 
 ---
 
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/pydate-fns)
 ![Code Climate coverage](https://img.shields.io/codeclimate/coverage/yashvesikar/pydate-fns)
 
-TODO: add documentation on how to use this library.
+## Installation
 
-Author: [Yash Vesikar](vesikar.com)
+```bash
+pip install pydate-fns
+```
 
+## Usage
 
-# date-fns parity
-<!-- methods -->
-method
+```python
+from datetime import datetime
+from pydate import is_weekday,
+
+if is_weekday(datetime.now()):
+    print("It's a weekday")
+else:
+    print("It's the weekend 😎")
+```
+
+<details>
+    <summary>date-fns methods parity</summary>
+    <!-- methods -->
+
+### method
+
 ---
+
 - [x] add
 - [ ] addBusinessDays
 - [x] addDays
@@ -124,29 +143,29 @@ method
 - [ ] intlFormatDistance
 - [x] isAfter
 - [x] isBefore
-- [ ] isDate
-- [ ] isEqual
-- [ ] isExists
-- [ ] isFirstDayOfMonth
-- [ ] isFriday
+- [x] isDate
+- [x] isEqual
+- [x] isExists
+- [x] isFirstDayOfMonth
+- [x] isFriday
 - [ ] isFuture
-- [ ] isLastDayOfMonth
-- [ ] isLeapYear
+- [x] isLastDayOfMonth
+- [x] isLeapYear
 - [ ] isMatch
-- [ ] isMonday
+- [x] isMonday
 - [ ] isPast
-- [ ] isSameDay
-- [ ] isSameHour
+- [x] isSameDay
+- [x] isSameHour
 - [ ] isSameISOWeek
 - [ ] isSameISOWeekYear
-- [ ] isSameMinute
-- [ ] isSameMonth
+- [x] isSameMinute
+- [x] isSameMonth
 - [ ] isSameQuarter
 - [ ] isSameSecond
 - [ ] isSameWeek
-- [ ] isSameYear
-- [ ] isSaturday
-- [ ] isSunday
+- [x] isSameYear
+- [x] isSaturday
+- [x] isSunday
 - [ ] isThisHour
 - [ ] isThisISOWeek
 - [ ] isThisMinute
@@ -155,12 +174,12 @@ method
 - [ ] isThisSecond
 - [ ] isThisWeek
 - [ ] isThisYear
-- [ ] isThursday
+- [x] isThursday
 - [ ] isToday
 - [ ] isTomorrow
-- [ ] isTuesday
+- [x] isTuesday
 - [ ] isValid
-- [ ] isWednesday
+- [x] isWednesday
 - [ ] isWeekend
 - [ ] isWithinInterval
 - [ ] isYesterday
@@ -258,4 +277,5 @@ method
 - [ ] weeksToDays
 - [ ] yearsToMonths
 - [ ] yearsToQuarters
-<!-- /methods -->
+  <!-- /methods -->
+      </details>

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -19,6 +19,7 @@ from pydate.is_friday import *
 from pydate.is_last_day_of_month import *
 from pydate.is_leap_year import *
 from pydate.is_monday import *
+from pydate.is_saturday import *
 from pydate.is_thursday import *
 from pydate.is_tuesday import *
 from pydate.is_wednesday import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -15,6 +15,7 @@ from pydate.is_date import *
 from pydate.is_equal import *
 from pydate.is_exists import *
 from pydate.is_first_day_of_month import *
+from pydate.is_friday import *
 from pydate.start_of_day import *
 from pydate.sub_days import *
 from pydate.sub_months import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -11,6 +11,7 @@ from pydate.add_years import *
 from pydate.closest_to import *
 from pydate.is_after import *
 from pydate.is_before import *
+from pydate.is_date import *
 from pydate.start_of_day import *
 from pydate.sub_days import *
 from pydate.sub_months import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -20,6 +20,7 @@ from pydate.is_last_day_of_month import *
 from pydate.is_leap_year import *
 from pydate.is_monday import *
 from pydate.is_saturday import *
+from pydate.is_sunday import *
 from pydate.is_thursday import *
 from pydate.is_tuesday import *
 from pydate.is_wednesday import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -22,6 +22,7 @@ from pydate.is_monday import *
 from pydate.is_same_day import *
 from pydate.is_same_hour import *
 from pydate.is_same_minute import *
+from pydate.is_same_year import *
 from pydate.is_saturday import *
 from pydate.is_sunday import *
 from pydate.is_thursday import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -16,6 +16,7 @@ from pydate.is_equal import *
 from pydate.is_exists import *
 from pydate.is_first_day_of_month import *
 from pydate.is_friday import *
+from pydate.is_last_day_of_month import *
 from pydate.start_of_day import *
 from pydate.sub_days import *
 from pydate.sub_months import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -14,6 +14,7 @@ from pydate.is_before import *
 from pydate.is_date import *
 from pydate.is_equal import *
 from pydate.is_exists import *
+from pydate.is_first_day_of_month import *
 from pydate.start_of_day import *
 from pydate.sub_days import *
 from pydate.sub_months import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -13,6 +13,7 @@ from pydate.is_after import *
 from pydate.is_before import *
 from pydate.is_date import *
 from pydate.is_equal import *
+from pydate.is_exists import *
 from pydate.start_of_day import *
 from pydate.sub_days import *
 from pydate.sub_months import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -17,6 +17,7 @@ from pydate.is_exists import *
 from pydate.is_first_day_of_month import *
 from pydate.is_friday import *
 from pydate.is_last_day_of_month import *
+from pydate.is_leap_year import *
 from pydate.start_of_day import *
 from pydate.sub_days import *
 from pydate.sub_months import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -22,6 +22,7 @@ from pydate.is_monday import *
 from pydate.is_same_day import *
 from pydate.is_same_hour import *
 from pydate.is_same_minute import *
+from pydate.is_same_month import *
 from pydate.is_same_year import *
 from pydate.is_saturday import *
 from pydate.is_sunday import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -23,6 +23,7 @@ from pydate.is_same_day import *
 from pydate.is_same_hour import *
 from pydate.is_same_minute import *
 from pydate.is_same_month import *
+from pydate.is_same_second import *
 from pydate.is_same_year import *
 from pydate.is_saturday import *
 from pydate.is_sunday import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -19,6 +19,7 @@ from pydate.is_friday import *
 from pydate.is_last_day_of_month import *
 from pydate.is_leap_year import *
 from pydate.is_monday import *
+from pydate.is_thursday import *
 from pydate.is_tuesday import *
 from pydate.is_wednesday import *
 from pydate.start_of_day import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -19,6 +19,7 @@ from pydate.is_friday import *
 from pydate.is_last_day_of_month import *
 from pydate.is_leap_year import *
 from pydate.is_monday import *
+from pydate.is_same_day import *
 from pydate.is_saturday import *
 from pydate.is_sunday import *
 from pydate.is_thursday import *
@@ -28,3 +29,4 @@ from pydate.start_of_day import *
 from pydate.sub_days import *
 from pydate.sub_months import *
 from pydate.to_date import *
+from pydate.to_naive import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -20,6 +20,7 @@ from pydate.is_last_day_of_month import *
 from pydate.is_leap_year import *
 from pydate.is_monday import *
 from pydate.is_tuesday import *
+from pydate.is_wednesday import *
 from pydate.start_of_day import *
 from pydate.sub_days import *
 from pydate.sub_months import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -21,6 +21,7 @@ from pydate.is_leap_year import *
 from pydate.is_monday import *
 from pydate.is_same_day import *
 from pydate.is_same_hour import *
+from pydate.is_same_minute import *
 from pydate.is_saturday import *
 from pydate.is_sunday import *
 from pydate.is_thursday import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -19,6 +19,7 @@ from pydate.is_friday import *
 from pydate.is_last_day_of_month import *
 from pydate.is_leap_year import *
 from pydate.is_monday import *
+from pydate.is_tuesday import *
 from pydate.start_of_day import *
 from pydate.sub_days import *
 from pydate.sub_months import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -12,6 +12,7 @@ from pydate.closest_to import *
 from pydate.is_after import *
 from pydate.is_before import *
 from pydate.is_date import *
+from pydate.is_equal import *
 from pydate.start_of_day import *
 from pydate.sub_days import *
 from pydate.sub_months import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -20,6 +20,7 @@ from pydate.is_last_day_of_month import *
 from pydate.is_leap_year import *
 from pydate.is_monday import *
 from pydate.is_same_day import *
+from pydate.is_same_hour import *
 from pydate.is_saturday import *
 from pydate.is_sunday import *
 from pydate.is_thursday import *

--- a/pydate/__init__.py
+++ b/pydate/__init__.py
@@ -18,6 +18,7 @@ from pydate.is_first_day_of_month import *
 from pydate.is_friday import *
 from pydate.is_last_day_of_month import *
 from pydate.is_leap_year import *
+from pydate.is_monday import *
 from pydate.start_of_day import *
 from pydate.sub_days import *
 from pydate.sub_months import *

--- a/pydate/is_date/__init__.py
+++ b/pydate/is_date/__init__.py
@@ -1,0 +1,1 @@
+from .is_date import is_date

--- a/pydate/is_date/is_date.py
+++ b/pydate/is_date/is_date.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+def is_date(date: datetime) -> bool:
+    """
+    Returns true if the given value is an instance of datetime.
+    
+    :param datetime date: _description_
+    :return bool: _description_
+    """
+    return isinstance(date, datetime)

--- a/pydate/is_date/is_date.py
+++ b/pydate/is_date/is_date.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 
+
 def is_date(date: datetime) -> bool:
     """
     Returns true if the given value is an instance of datetime.
-    
-    :param datetime date: _description_
-    :return bool: _description_
+
+    :param datetime date: datetime object
+    :return bool: Returns true if the given value is an instance of datetime, False otherwise
     """
     return isinstance(date, datetime)

--- a/pydate/is_date/test.py
+++ b/pydate/is_date/test.py
@@ -1,0 +1,13 @@
+import unittest
+from datetime import datetime
+
+from .is_date import is_date
+
+
+class TestIsDate(unittest.TestCase):
+    def test_is_date(self) -> None:
+
+        self.assertTrue(is_date(datetime.now()), "should return true if the given value is an instance of datetime")
+
+    def test_is_not_date(self) -> None:
+        self.assertFalse(is_date("2021-01-01"), "should return false if the given value is not an instance of datetime")

--- a/pydate/is_date/test.py
+++ b/pydate/is_date/test.py
@@ -10,4 +10,4 @@ class TestIsDate(unittest.TestCase):
         self.assertTrue(is_date(datetime.now()), "should return true if the given value is an instance of datetime")
 
     def test_is_not_date(self) -> None:
-        self.assertFalse(is_date("2021-01-01"), "should return false if the given value is not an instance of datetime")
+        self.assertFalse(is_date("2021-01-01"), "should return false if the given value is not an instance of datetime")  # type: ignore

--- a/pydate/is_equal/__init__.py
+++ b/pydate/is_equal/__init__.py
@@ -1,0 +1,1 @@
+from .is_equal import is_equal

--- a/pydate/is_equal/is_equal.py
+++ b/pydate/is_equal/is_equal.py
@@ -6,7 +6,8 @@ def is_equal(date: datetime, to_compare: datetime) -> bool:
     Returns True if the given dates are equal.
 
     :param datetime date: datetime object
-    :return bool: _description_
+    :param datetime to_compare: datetime object to compare
+    :return bool: True if the given dates are equal, False otherwise
     """
     if not isinstance(date, datetime):
         raise TypeError("date must be an instance of datetime")

--- a/pydate/is_equal/is_equal.py
+++ b/pydate/is_equal/is_equal.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+
+def is_equal(date: datetime, to_compare: datetime) -> bool:
+    """
+    Returns True if the given dates are equal.
+
+    :param datetime date: datetime object
+    :return bool: _description_
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+    if not isinstance(to_compare, datetime):
+        raise TypeError("to_compare must be an instance of datetime")
+
+    return date == to_compare

--- a/pydate/is_equal/test.py
+++ b/pydate/is_equal/test.py
@@ -1,0 +1,29 @@
+import unittest
+from datetime import datetime
+
+from .is_equal import is_equal
+
+
+class TestIsEqual(unittest.TestCase):
+    def test_is_equal(self) -> None:
+        print(datetime(1987, 1, 11), datetime(1987, 1, 11))
+        self.assertTrue(is_equal(datetime(1987, 1, 11), datetime(1987, 1, 11)), "should return true if the given dates are equal")
+
+    def test_is_not_equal(self) -> None:
+        self.assertFalse(is_equal(datetime(1987, 1, 11), datetime(1987, 1, 12)), "should return false if the given dates are not equal")
+
+    def test_is_equal_timestamps(self) -> None:
+        # TODO: want to add this test once pydate is able to handle dirty dates
+        pass
+
+    def test_is_equal_bad_first_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_equal("1987-01-11", datetime(1987, 1, 11))  # type: ignore
+
+    def test_is_equal_bad_second_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_equal(datetime(1987, 1, 11), "1987-01-11")  # type: ignore
+
+    def test_is_equal_bad_both_dates(self) -> None:
+        with self.assertRaises(TypeError):
+            is_equal("1987-01-11", "1987-01-11")  # type: ignore

--- a/pydate/is_exists/__init__.py
+++ b/pydate/is_exists/__init__.py
@@ -1,0 +1,1 @@
+from .is_exists import is_exists

--- a/pydate/is_exists/is_exists.py
+++ b/pydate/is_exists/is_exists.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+
+def is_exists(year: int, month: int, day: int) -> bool:
+    """
+    Checks if the given arguments convert to an existing date.
+
+    :param int year: year of the date to check
+    :param int month: month of the date to check
+    :param int day: day of the date to check
+    :return bool: True if the given arguments convert to an existing date, False otherwise
+    """
+    try:
+        datetime(year, month, day)
+        return True
+    except (ValueError, TypeError) as e:
+        print(e)
+        return False

--- a/pydate/is_exists/test.py
+++ b/pydate/is_exists/test.py
@@ -1,0 +1,12 @@
+import unittest
+from datetime import datetime
+
+from .is_exists import is_exists
+
+
+class Testis_exists(unittest.TestCase):
+    def test_is_exists(self) -> None:
+        self.assertTrue(is_exists(2018, 1, 31), "should return true if the given date is valid")
+
+    def test_is_not_exists(self) -> None:
+        self.assertFalse(is_exists(2018, 2, 31), "should return false if the given date is invalid")

--- a/pydate/is_first_day_of_month/__init__.py
+++ b/pydate/is_first_day_of_month/__init__.py
@@ -1,0 +1,1 @@
+from .is_first_day_of_month import is_first_day_of_month

--- a/pydate/is_first_day_of_month/is_first_day_of_month.py
+++ b/pydate/is_first_day_of_month/is_first_day_of_month.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+
+def is_first_day_of_month(date: datetime) -> bool:
+    """
+    Is the given date the first day of a month?
+
+    :param datetime date: datetime object
+    :return bool: True if the given date is the first day of a month, False otherwise
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    return date.day == 1

--- a/pydate/is_first_day_of_month/test.py
+++ b/pydate/is_first_day_of_month/test.py
@@ -1,0 +1,16 @@
+import unittest
+from datetime import datetime
+
+from .is_first_day_of_month import is_first_day_of_month
+
+
+class TestIsFirstDayOfMonth(unittest.TestCase):
+    def test_is_first_day_of_month(self) -> None:
+        self.assertTrue(is_first_day_of_month(datetime(2014, 10, 1)), "should return true if the given date is the first day of a month")
+
+    def test_is_not_first_day_of_month(self) -> None:
+        self.assertFalse(is_first_day_of_month(datetime(2014, 10, 2)), "should return false if the given date is not the first day of a month")
+
+    def test_is_first_day_of_month_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_first_day_of_month("2014-10-01")  # type: ignore

--- a/pydate/is_friday/__init__.py
+++ b/pydate/is_friday/__init__.py
@@ -1,0 +1,1 @@
+from .is_friday import is_friday

--- a/pydate/is_friday/is_friday.py
+++ b/pydate/is_friday/is_friday.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+
+def is_friday(date: datetime) -> bool:
+    """
+    Is the given date a Friday?
+
+    :param datetime date: datetime object
+    :return bool: True if the given date is a Friday, False otherwise
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    return date.weekday() == 4

--- a/pydate/is_friday/test.py
+++ b/pydate/is_friday/test.py
@@ -1,0 +1,16 @@
+import unittest
+from datetime import datetime
+
+from .is_friday import is_friday
+
+
+class TestIsFriday(unittest.TestCase):
+    def test_is_friday(self) -> None:
+        self.assertTrue(is_friday(datetime(2014, 9, 26)), "should return true if the given date is a Friday")
+
+    def test_is_not_friday(self) -> None:
+        self.assertFalse(is_friday(datetime(2014, 9, 25)), "should return false if the given date is not a Friday")
+
+    def test_is_friday_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_friday("2014-09-26")  # type: ignore

--- a/pydate/is_last_day_of_month/__init__.py
+++ b/pydate/is_last_day_of_month/__init__.py
@@ -1,0 +1,1 @@
+from .is_last_day_of_month import is_last_day_of_month

--- a/pydate/is_last_day_of_month/is_last_day_of_month.py
+++ b/pydate/is_last_day_of_month/is_last_day_of_month.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timedelta
+
+
+def is_last_day_of_month(date: datetime) -> bool:
+    """
+    Is the given date the last day of a month?
+
+    :param datetime date: datetime object
+    :return bool: True if the date is the last day of a month, False otherwise
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be a datetime object")
+
+    return date.month != (date + timedelta(days=1)).month

--- a/pydate/is_last_day_of_month/test.py
+++ b/pydate/is_last_day_of_month/test.py
@@ -1,0 +1,22 @@
+import unittest
+from datetime import datetime
+
+from .is_last_day_of_month import is_last_day_of_month
+
+
+class TestIsLastDayOfMonth(unittest.TestCase):
+    def test_is_last_day_of_month(self) -> None:
+        self.assertTrue(is_last_day_of_month(datetime(2014, 10, 31)))
+
+    def test_is_not_last_day_of_month(self) -> None:
+        self.assertFalse(is_last_day_of_month(datetime(2014, 10, 30)))
+
+    def test_is_last_day_of_month_with_leap_year(self) -> None:
+        self.assertTrue(is_last_day_of_month(datetime(2016, 2, 29)))
+
+    def test_is_not_last_day_of_month_with_leap_year(self) -> None:
+        self.assertFalse(is_last_day_of_month(datetime(2016, 2, 28)))
+
+    def test_is_last_day_of_month_bad_input(self) -> None:
+        with self.assertRaises(TypeError):
+            is_last_day_of_month("2014-10-31")  # type: ignore

--- a/pydate/is_leap_year/__init__.py
+++ b/pydate/is_leap_year/__init__.py
@@ -1,0 +1,1 @@
+from .is_leap_year import is_leap_year

--- a/pydate/is_leap_year/is_leap_year.py
+++ b/pydate/is_leap_year/is_leap_year.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+
+def is_leap_year(date: datetime) -> bool:
+    """
+    Is the given date in the leap year?
+
+    :param datetime date: datetime object
+    :return bool: True if the date is in the leap year, False otherwise
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be a datetime object")
+
+    return date.year % 4 == 0 and (date.year % 100 != 0 or date.year % 400 == 0)

--- a/pydate/is_leap_year/test.py
+++ b/pydate/is_leap_year/test.py
@@ -1,0 +1,22 @@
+import unittest
+from datetime import datetime
+
+from .is_leap_year import is_leap_year
+
+
+class TestIsLeapYear(unittest.TestCase):
+    def test_is_leap_year(self) -> None:
+        self.assertTrue(is_leap_year(datetime(2012, 7, 2)), "returns True if the date is in a leap year")
+
+    def test_is_not_leap_year(self) -> None:
+        self.assertFalse(is_leap_year(datetime(2014, 7, 2)), "returns False if the date is not in a leap year")
+
+    def test_is_not_leap_year_century(self) -> None:
+        self.assertFalse(is_leap_year(datetime(2100, 7, 2)), "works for years divisible by 100 but not 400")
+
+    def test_is_leap_year_century(self) -> None:
+        self.assertTrue(is_leap_year(datetime(2000, 7, 2)), "works for years divisible by 400")
+
+    def test_is_leap_year_bad_input(self) -> None:
+        with self.assertRaises(TypeError):
+            is_leap_year("2014-10-31")  # type: ignore

--- a/pydate/is_monday/__init__.py
+++ b/pydate/is_monday/__init__.py
@@ -1,0 +1,1 @@
+from .is_monday import is_monday

--- a/pydate/is_monday/is_monday.py
+++ b/pydate/is_monday/is_monday.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+
+def is_monday(date: datetime) -> bool:
+    """
+    Is the given date a Monday?
+
+    :param datetime date: datetime object
+    :return bool: True if the given date is a Monday, False otherwise
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    return date.weekday() == 0

--- a/pydate/is_monday/test.py
+++ b/pydate/is_monday/test.py
@@ -4,12 +4,12 @@ from datetime import datetime
 from .is_monday import is_monday
 
 
-class TestIsFriday(unittest.TestCase):
+class TestIsMonday(unittest.TestCase):
     def test_is_monday(self) -> None:
-        self.assertTrue(is_monday(datetime(2014, 9, 22)), "should return true if the given date is a Friday")
+        self.assertTrue(is_monday(datetime(2014, 9, 22)), "should return true if the given date is a Monday")
 
     def test_is_not_tuesday(self) -> None:
-        self.assertFalse(is_monday(datetime(2014, 9, 25)), "should return false if the given date is not a Friday")
+        self.assertFalse(is_monday(datetime(2014, 9, 25)), "should return false if the given date is not a Monday")
 
     def test_is_monday_bad_date(self) -> None:
         with self.assertRaises(TypeError):

--- a/pydate/is_monday/test.py
+++ b/pydate/is_monday/test.py
@@ -1,0 +1,16 @@
+import unittest
+from datetime import datetime
+
+from .is_monday import is_monday
+
+
+class TestIsFriday(unittest.TestCase):
+    def test_is_monday(self) -> None:
+        self.assertTrue(is_monday(datetime(2014, 9, 22)), "should return true if the given date is a Friday")
+
+    def test_is_not_friday(self) -> None:
+        self.assertFalse(is_monday(datetime(2014, 9, 25)), "should return false if the given date is not a Friday")
+
+    def test_is_monday_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_monday("2014-09-26")  # type: ignore

--- a/pydate/is_monday/test.py
+++ b/pydate/is_monday/test.py
@@ -8,7 +8,7 @@ class TestIsFriday(unittest.TestCase):
     def test_is_monday(self) -> None:
         self.assertTrue(is_monday(datetime(2014, 9, 22)), "should return true if the given date is a Friday")
 
-    def test_is_not_friday(self) -> None:
+    def test_is_not_tuesday(self) -> None:
         self.assertFalse(is_monday(datetime(2014, 9, 25)), "should return false if the given date is not a Friday")
 
     def test_is_monday_bad_date(self) -> None:

--- a/pydate/is_same_day/__init__.py
+++ b/pydate/is_same_day/__init__.py
@@ -1,0 +1,1 @@
+from .is_same_day import is_same_day

--- a/pydate/is_same_day/is_same_day.py
+++ b/pydate/is_same_day/is_same_day.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from ..to_naive import to_naive
+
+
+def is_same_day(date: datetime, to_compare: datetime) -> bool:
+    """
+    Is the given date the same day as the to_compare date?
+    converts both dates to naive utc datetime objects before comparing
+
+    :param datetime date: datetime object
+    :param datetime to_compare: datetime object
+    :return bool: True if the given date is the same day (and year and month) as the to_compare date, False otherwise
+    """
+
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    if not isinstance(to_compare, datetime):
+        raise TypeError("to_compare must be an instance of datetime")
+
+    left = to_naive(date)
+    right = to_naive(to_compare)
+
+    return left.year == right.year and left.month == right.month and left.day == right.day

--- a/pydate/is_same_day/test.py
+++ b/pydate/is_same_day/test.py
@@ -1,0 +1,45 @@
+import unittest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from .is_same_day import is_same_day
+
+
+class TestIsSameDay(unittest.TestCase):
+    def test_is_same_day(self) -> None:
+        self.assertTrue(is_same_day(datetime(2014, 9, 4, 6, 0), datetime(2014, 9, 4, 18, 0)), "should return true if the given dates are the same")
+
+    def test_is_not_same_day(self) -> None:
+        self.assertFalse(
+            is_same_day(datetime(2014, 9, 4, 23, 59), datetime(2014, 9, 5, 0, 0)), "should return false if the given dates are not the same"
+        )
+
+    def test_is_same_day_timezone_aware(self) -> None:
+
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+        self.assertTrue(
+            is_same_day(datetime(2014, 9, 4, 18, 59, 0, tzinfo=est), datetime(2014, 9, 4, 23, 59, 0, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_not_same_day_timezone_aware(self) -> None:
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+
+        self.assertTrue(
+            is_same_day(datetime(2014, 9, 4, 18, 0, 0, tzinfo=est), datetime(2014, 9, 4, 23, 59, 0, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_same_day_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_day("2014-09-26", datetime(2014, 9, 4, 23, 59))  # type: ignore
+
+    def test_is_same_day_bad_date2(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_day(datetime(2014, 9, 4, 23, 59), "2014-09-26")  # type: ignore
+
+    def test_is_same_day_bad_date3(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_day("2014-09-26", "2014-09-26")  # type: ignore

--- a/pydate/is_same_day/test.py
+++ b/pydate/is_same_day/test.py
@@ -18,8 +18,14 @@ class TestIsSameDay(unittest.TestCase):
 
         utc = ZoneInfo("UTC")
         est = ZoneInfo("EST")
+        ind = ZoneInfo("Asia/Kolkata")
         self.assertTrue(
             is_same_day(datetime(2014, 9, 4, 18, 59, 0, tzinfo=est), datetime(2014, 9, 4, 23, 59, 0, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+        self.assertTrue(
+            is_same_day(datetime(2014, 9, 4, 18, 59, 0, tzinfo=est), datetime(2014, 9, 5, 4, 59, 0, tzinfo=ind)),
             "should return true if the given dates are the same",
         )
 
@@ -27,8 +33,8 @@ class TestIsSameDay(unittest.TestCase):
         utc = ZoneInfo("UTC")
         est = ZoneInfo("EST")
 
-        self.assertTrue(
-            is_same_day(datetime(2014, 9, 4, 18, 0, 0, tzinfo=est), datetime(2014, 9, 4, 23, 59, 0, tzinfo=utc)),
+        self.assertFalse(
+            is_same_day(datetime(2014, 9, 4, 18, 59, 0, tzinfo=est), datetime(2014, 9, 5, 1, 0, 0, tzinfo=utc)),
             "should return true if the given dates are the same",
         )
 

--- a/pydate/is_same_hour/__init__.py
+++ b/pydate/is_same_hour/__init__.py
@@ -1,0 +1,1 @@
+from .is_same_hour import is_same_hour

--- a/pydate/is_same_hour/is_same_hour.py
+++ b/pydate/is_same_hour/is_same_hour.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from ..to_naive import to_naive
+
+
+def is_same_hour(date: datetime, to_compare: datetime) -> bool:
+    """
+    Is the given date in the same hour as the given date to compare?
+    converts both dates to naive utc datetime objects before comparing
+
+    :param datetime date: datetime object
+    :param datetime to_compare: datetime object
+    :return bool: True if the given date is in the same hour as the to_compare date, False otherwise
+    """
+
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    if not isinstance(to_compare, datetime):
+        raise TypeError("to_compare must be an instance of datetime")
+
+    left = to_naive(date)
+    right = to_naive(to_compare)
+
+    return left.year == right.year and left.month == right.month and left.day == right.day and left.hour == right.hour

--- a/pydate/is_same_hour/test.py
+++ b/pydate/is_same_hour/test.py
@@ -20,7 +20,6 @@ class TestIsSameHour(unittest.TestCase):
 
         utc = ZoneInfo("UTC")
         est = ZoneInfo("EST")
-        ind = ZoneInfo("Asia/Kolkata")
         self.assertTrue(
             is_same_hour(datetime(2014, 9, 4, 18, 0, 0, tzinfo=est), datetime(2014, 9, 4, 23, 30, 0, tzinfo=utc)),
             "should return true if the given dates are the same",

--- a/pydate/is_same_hour/test.py
+++ b/pydate/is_same_hour/test.py
@@ -1,0 +1,48 @@
+import unittest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from .is_same_hour import is_same_hour
+
+
+class TestIsSameHour(unittest.TestCase):
+    def test_is_same_hour(self) -> None:
+        self.assertTrue(
+            is_same_hour(datetime(2014, 9, 4, 6, 0), datetime(2014, 9, 4, 6, 30)), "should return true if the given dates are in the same hour"
+        )
+
+    def test_is_not_same_hour(self) -> None:
+        self.assertFalse(
+            is_same_hour(datetime(2014, 9, 4, 6, 0), datetime(2014, 9, 25, 5, 0)), "should return false if the given dates are not in the same hour"
+        )
+
+    def test_is_same_hour_timezone_aware(self) -> None:
+
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+        ind = ZoneInfo("Asia/Kolkata")
+        self.assertTrue(
+            is_same_hour(datetime(2014, 9, 4, 18, 0, 0, tzinfo=est), datetime(2014, 9, 4, 23, 30, 0, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_not_same_hour_timezone_aware(self) -> None:
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+
+        self.assertFalse(
+            is_same_hour(datetime(2014, 9, 4, 17, 59, 0, tzinfo=est), datetime(2014, 9, 4, 23, 59, 0, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_same_hour_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_hour("2014-09-26", datetime(2014, 9, 26))  # type: ignore
+
+    def test_is_same_hour_bad_date2(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_hour(datetime(2014, 9, 26), "2014-09-26")  # type: ignore
+
+    def test_is_same_hour_bad_date3(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_hour("2014-09-26", "2014-09-26")  # type: ignore

--- a/pydate/is_same_minute/__init__.py
+++ b/pydate/is_same_minute/__init__.py
@@ -1,0 +1,1 @@
+from .is_same_minute import is_same_minute

--- a/pydate/is_same_minute/is_same_minute.py
+++ b/pydate/is_same_minute/is_same_minute.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from ..to_naive import to_naive
+
+
+def is_same_minute(date: datetime, to_compare: datetime) -> bool:
+    """
+    Is the given date in the same minute as the given date to compare?
+    converts both dates to naive utc datetime objects before comparing
+
+    :param datetime date: datetime object
+    :param datetime to_compare: datetime object
+    :return bool: True if the given date is in the same minute as the to_compare date, False otherwise
+    """
+
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    if not isinstance(to_compare, datetime):
+        raise TypeError("to_compare must be an instance of datetime")
+
+    left = to_naive(date)
+    right = to_naive(to_compare)
+
+    return left.year == right.year and left.month == right.month and left.day == right.day and left.hour == right.hour and left.minute == right.minute

--- a/pydate/is_same_minute/test.py
+++ b/pydate/is_same_minute/test.py
@@ -1,0 +1,48 @@
+import unittest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from .is_same_minute import is_same_minute
+
+
+class TestIsSameminute(unittest.TestCase):
+    def test_is_same_minute(self) -> None:
+        self.assertTrue(
+            is_same_minute(datetime(2014, 9, 4, 6, 0), datetime(2014, 9, 4, 6, 0)), "should return true if the given dates are in the same minute"
+        )
+
+    def test_is_not_same_minute(self) -> None:
+        self.assertFalse(
+            is_same_minute(datetime(2014, 9, 4, 6, 0), datetime(2014, 9, 25, 6, 30)),
+            "should return false if the given dates are not in the same minute",
+        )
+
+    def test_is_same_minute_timezone_aware(self) -> None:
+
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+        self.assertTrue(
+            is_same_minute(datetime(2014, 9, 4, 18, 0, 0, tzinfo=est), datetime(2014, 9, 4, 23, 0, 0, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_not_same_minute_timezone_aware(self) -> None:
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+
+        self.assertFalse(
+            is_same_minute(datetime(2014, 9, 4, 18, 59, tzinfo=est), datetime(2014, 9, 5, 0, 0, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_same_minute_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_minute("2014-09-26", datetime(2014, 9, 26, 1, 1))  # type: ignore
+
+    def test_is_same_minute_bad_date2(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_minute(datetime(2014, 9, 26, 1, 1), "2014-09-26")  # type: ignore
+
+    def test_is_same_minute_bad_date3(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_minute("2014-09-26", "2014-09-26")  # type: ignore

--- a/pydate/is_same_month/__init__.py
+++ b/pydate/is_same_month/__init__.py
@@ -1,0 +1,1 @@
+from .is_same_month import is_same_month

--- a/pydate/is_same_month/is_same_month.py
+++ b/pydate/is_same_month/is_same_month.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from ..to_naive import to_naive
+
+
+def is_same_month(date: datetime, to_compare: datetime) -> bool:
+    """
+    Is the given date the same month as the to_compare date?
+    converts both dates to naive utc datetime objects before comparing
+
+    :param datetime date: datetime object
+    :param datetime to_compare: datetime object
+    :return bool: True if the given date is the same month (and year and month) as the to_compare date, False otherwise
+    """
+
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    if not isinstance(to_compare, datetime):
+        raise TypeError("to_compare must be an instance of datetime")
+
+    left = to_naive(date)
+    right = to_naive(to_compare)
+
+    return left.year == right.year and left.month == right.month

--- a/pydate/is_same_month/test.py
+++ b/pydate/is_same_month/test.py
@@ -1,0 +1,49 @@
+import unittest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from .is_same_month import is_same_month
+
+
+class TestIsSameMonth(unittest.TestCase):
+    def test_is_same_month(self) -> None:
+        self.assertTrue(is_same_month(datetime(2014, 9, 4), datetime(2014, 9, 24)), "should return true if the given dates are the same")
+
+    def test_is_not_same_month(self) -> None:
+        self.assertFalse(is_same_month(datetime(2014, 9, 4), datetime(2014, 10, 4)), "should return false if the given dates are not the same")
+
+    def test_is_same_month_timezone_aware(self) -> None:
+
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+        ind = ZoneInfo("Asia/Kolkata")
+        self.assertTrue(
+            is_same_month(datetime(2014, 9, 30, 19, 30, tzinfo=est), datetime(2014, 10, 1, 0, 30, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+        self.assertTrue(
+            is_same_month(datetime(2014, 9, 30, 19, 30, tzinfo=est), datetime(2014, 10, 6, 0, 30, tzinfo=ind)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_not_same_month_timezone_aware(self) -> None:
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+
+        self.assertFalse(
+            is_same_month(datetime(2014, 9, 30, 18, 59, 0, tzinfo=est), datetime(2014, 10, 1, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_same_month_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_month("2014-09-26", datetime(2014, 9, 4, 23, 59))  # type: ignore
+
+    def test_is_same_month_bad_date2(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_month(datetime(2014, 9, 4, 23, 59), "2014-09-26")  # type: ignore
+
+    def test_is_same_month_bad_date3(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_month("2014-09-26", "2014-09-26")  # type: ignore

--- a/pydate/is_same_second/__init__.py
+++ b/pydate/is_same_second/__init__.py
@@ -1,0 +1,1 @@
+from .is_same_second import is_same_second

--- a/pydate/is_same_second/is_same_second.py
+++ b/pydate/is_same_second/is_same_second.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+from ..to_naive import to_naive
+
+
+def is_same_second(date: datetime, to_compare: datetime) -> bool:
+    """
+    Is the given date in the same second as the given date to compare?
+    converts both dates to naive utc datetime objects before comparing
+
+    :param datetime date: datetime object
+    :param datetime to_compare: datetime object
+    :return bool: True if the given date is in the same second as the to_compare date, False otherwise
+    """
+
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    if not isinstance(to_compare, datetime):
+        raise TypeError("to_compare must be an instance of datetime")
+
+    left = to_naive(date)
+    right = to_naive(to_compare)
+
+    return (
+        left.year == right.year
+        and left.month == right.month
+        and left.day == right.day
+        and left.hour == right.hour
+        and left.minute == right.minute
+        and left.second == right.second
+    )

--- a/pydate/is_same_second/test.py
+++ b/pydate/is_same_second/test.py
@@ -1,0 +1,48 @@
+import unittest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from .is_same_second import is_same_second
+
+
+class TestIsSameSecond(unittest.TestCase):
+    def test_is_same_second(self) -> None:
+        self.assertTrue(
+            is_same_second(datetime(2014, 9, 4, 6, 0), datetime(2014, 9, 4, 6, 0)), "should return true if the given dates are in the same second"
+        )
+
+    def test_is_not_same_second(self) -> None:
+        self.assertFalse(
+            is_same_second(datetime(2014, 9, 4, 6, 0), datetime(2014, 9, 25, 6, 30)),
+            "should return false if the given dates are not in the same second",
+        )
+
+    def test_is_same_second_timezone_aware(self) -> None:
+
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+        self.assertTrue(
+            is_same_second(datetime(2014, 9, 4, 18, 0, tzinfo=est), datetime(2014, 9, 4, 23, 0, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_not_same_second_timezone_aware(self) -> None:
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+
+        self.assertFalse(
+            is_same_second(datetime(2014, 9, 4, 18, 59, tzinfo=est), datetime(2014, 9, 5, 0, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_same_second_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_second("2014-09-26", datetime(2014, 9, 26, 1, 1))  # type: ignore
+
+    def test_is_same_second_bad_date2(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_second(datetime(2014, 9, 26, 1, 1), "2014-09-26")  # type: ignore
+
+    def test_is_same_second_bad_date3(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_second("2014-09-26", "2014-09-26")  # type: ignore

--- a/pydate/is_same_year/__init__.py
+++ b/pydate/is_same_year/__init__.py
@@ -1,0 +1,1 @@
+from .is_same_year import is_same_year

--- a/pydate/is_same_year/is_same_year.py
+++ b/pydate/is_same_year/is_same_year.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from ..to_naive import to_naive
+
+
+def is_same_year(date: datetime, to_compare: datetime) -> bool:
+    """
+    Is the given date the same year as the to_compare date?
+    converts both dates to naive utc datetime objects before comparing
+
+    :param datetime date: datetime object
+    :param datetime to_compare: datetime object
+    :return bool: True if the given date is the same year (and year and month) as the to_compare date, False otherwise
+    """
+
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    if not isinstance(to_compare, datetime):
+        raise TypeError("to_compare must be an instance of datetime")
+
+    left = to_naive(date)
+    right = to_naive(to_compare)
+
+    return left.year == right.year

--- a/pydate/is_same_year/test.py
+++ b/pydate/is_same_year/test.py
@@ -1,0 +1,49 @@
+import unittest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from .is_same_year import is_same_year
+
+
+class TestIsSameyear(unittest.TestCase):
+    def test_is_same_year(self) -> None:
+        self.assertTrue(is_same_year(datetime(2014, 9, 4), datetime(2014, 12, 1)), "should return true if the given dates are the same")
+
+    def test_is_not_same_year(self) -> None:
+        self.assertFalse(is_same_year(datetime(2014, 9, 4), datetime(2015, 3, 5)), "should return false if the given dates are not the same")
+
+    def test_is_same_year_timezone_aware(self) -> None:
+
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+        ind = ZoneInfo("Asia/Kolkata")
+        self.assertTrue(
+            is_same_year(datetime(2014, 12, 31, 13, 59, tzinfo=est), datetime(2014, 12, 31, 18, 59, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+        self.assertTrue(
+            is_same_year(datetime(2014, 12, 31, 11, 59, tzinfo=est), datetime(2014, 12, 31, 11, 59, tzinfo=ind)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_not_same_year_timezone_aware(self) -> None:
+        utc = ZoneInfo("UTC")
+        est = ZoneInfo("EST")
+
+        self.assertFalse(
+            is_same_year(datetime(2014, 12, 31, 18, 59, tzinfo=est), datetime(2015, 1, 1, tzinfo=utc)),
+            "should return true if the given dates are the same",
+        )
+
+    def test_is_same_year_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_year("2014-09-26", datetime(2014, 9, 4, 23, 59))  # type: ignore
+
+    def test_is_same_year_bad_date2(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_year(datetime(2014, 9, 4, 23, 59), "2014-09-26")  # type: ignore
+
+    def test_is_same_year_bad_date3(self) -> None:
+        with self.assertRaises(TypeError):
+            is_same_year("2014-09-26", "2014-09-26")  # type: ignore

--- a/pydate/is_saturday/__init__.py
+++ b/pydate/is_saturday/__init__.py
@@ -1,0 +1,1 @@
+from .is_saturday import is_saturday

--- a/pydate/is_saturday/is_saturday.py
+++ b/pydate/is_saturday/is_saturday.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+
+def is_saturday(date: datetime) -> bool:
+    """
+    Is the given date a Saturday?
+
+    :param datetime date: datetime object
+    :return bool: True if the given date is a saturday, False otherwise
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    return date.weekday() == 5

--- a/pydate/is_saturday/test.py
+++ b/pydate/is_saturday/test.py
@@ -1,0 +1,16 @@
+import unittest
+from datetime import datetime
+
+from .is_saturday import is_saturday
+
+
+class TestIsSaturday(unittest.TestCase):
+    def test_is_saturday(self) -> None:
+        self.assertTrue(is_saturday(datetime(2014, 9, 27)), "should return true if the given date is a Saturday")
+
+    def test_is_not_saturday(self) -> None:
+        self.assertFalse(is_saturday(datetime(2014, 9, 25)), "should return false if the given date is not a Saturday")
+
+    def test_is_saturday_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_saturday("2014-09-26")  # type: ignore

--- a/pydate/is_sunday/__init__.py
+++ b/pydate/is_sunday/__init__.py
@@ -1,0 +1,1 @@
+from .is_sunday import is_sunday

--- a/pydate/is_sunday/is_sunday.py
+++ b/pydate/is_sunday/is_sunday.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+
+def is_sunday(date: datetime) -> bool:
+    """
+    Is the given date a Sunday?
+
+    :param datetime date: datetime object
+    :return bool: True if the given date is a Sunday, False otherwise
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    return date.weekday() == 6

--- a/pydate/is_sunday/test.py
+++ b/pydate/is_sunday/test.py
@@ -1,0 +1,16 @@
+import unittest
+from datetime import datetime
+
+from .is_sunday import is_sunday
+
+
+class TestIsSunday(unittest.TestCase):
+    def test_is_sunday(self) -> None:
+        self.assertTrue(is_sunday(datetime(2014, 9, 28)), "should return true if the given date is a Sunday")
+
+    def test_is_not_sunday(self) -> None:
+        self.assertFalse(is_sunday(datetime(2014, 9, 25)), "should return false if the given date is not a Sunday")
+
+    def test_is_sunday_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_sunday("2014-09-26")  # type: ignore

--- a/pydate/is_thursday/__init__.py
+++ b/pydate/is_thursday/__init__.py
@@ -1,0 +1,1 @@
+from .is_thursday import is_thursday

--- a/pydate/is_thursday/is_thursday.py
+++ b/pydate/is_thursday/is_thursday.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+
+def is_thursday(date: datetime) -> bool:
+    """
+    Is the given date a thursday?
+
+    :param datetime date: datetime object
+    :return bool: True if the given date is a thursday, False otherwise
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    return date.weekday() == 3

--- a/pydate/is_thursday/test.py
+++ b/pydate/is_thursday/test.py
@@ -6,10 +6,10 @@ from .is_thursday import is_thursday
 
 class TestIsThursday(unittest.TestCase):
     def test_is_thursday(self) -> None:
-        self.assertTrue(is_thursday(datetime(2014, 9, 24)), "should return true if the given date is a Thursday")
+        self.assertTrue(is_thursday(datetime(2014, 9, 25)), "should return true if the given date is a Thursday")
 
-    def test_is_not_tueday(self) -> None:
-        self.assertFalse(is_thursday(datetime(2014, 9, 25)), "should return false if the given date is not a Thursday")
+    def test_is_not_thursday(self) -> None:
+        self.assertFalse(is_thursday(datetime(2014, 9, 24)), "should return false if the given date is not a Thursday")
 
     def test_is_thursday_bad_date(self) -> None:
         with self.assertRaises(TypeError):

--- a/pydate/is_thursday/test.py
+++ b/pydate/is_thursday/test.py
@@ -1,0 +1,16 @@
+import unittest
+from datetime import datetime
+
+from .is_thursday import is_thursday
+
+
+class TestIsThursday(unittest.TestCase):
+    def test_is_thursday(self) -> None:
+        self.assertTrue(is_thursday(datetime(2014, 9, 24)), "should return true if the given date is a Thursday")
+
+    def test_is_not_tueday(self) -> None:
+        self.assertFalse(is_thursday(datetime(2014, 9, 25)), "should return false if the given date is not a Thursday")
+
+    def test_is_thursday_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_thursday("2014-09-26")  # type: ignore

--- a/pydate/is_tuesday/__init__.py
+++ b/pydate/is_tuesday/__init__.py
@@ -1,0 +1,1 @@
+from .is_tuesday import is_tuesday

--- a/pydate/is_tuesday/is_tuesday.py
+++ b/pydate/is_tuesday/is_tuesday.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+
+def is_tuesday(date: datetime) -> bool:
+    """
+    Is the given date a Tuesday?
+
+    :param datetime date: datetime object
+    :return bool: True if the given date is a Tuesday, False otherwise
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    return date.weekday() == 1

--- a/pydate/is_tuesday/test.py
+++ b/pydate/is_tuesday/test.py
@@ -4,12 +4,12 @@ from datetime import datetime
 from .is_tuesday import is_tuesday
 
 
-class TestIsFriday(unittest.TestCase):
+class TestIsTuesday(unittest.TestCase):
     def test_is_tuesday(self) -> None:
-        self.assertTrue(is_tuesday(datetime(2014, 9, 23)), "should return true if the given date is a Friday")
+        self.assertTrue(is_tuesday(datetime(2014, 9, 23)), "should return true if the given date is a Tuesday")
 
     def test_is_not_tueday(self) -> None:
-        self.assertFalse(is_tuesday(datetime(2014, 9, 25)), "should return false if the given date is not a Friday")
+        self.assertFalse(is_tuesday(datetime(2014, 9, 25)), "should return false if the given date is not a Tuesday")
 
     def test_is_tuesday_bad_date(self) -> None:
         with self.assertRaises(TypeError):

--- a/pydate/is_tuesday/test.py
+++ b/pydate/is_tuesday/test.py
@@ -1,0 +1,16 @@
+import unittest
+from datetime import datetime
+
+from .is_tuesday import is_tuesday
+
+
+class TestIsFriday(unittest.TestCase):
+    def test_is_tuesday(self) -> None:
+        self.assertTrue(is_tuesday(datetime(2014, 9, 23)), "should return true if the given date is a Friday")
+
+    def test_is_not_tueday(self) -> None:
+        self.assertFalse(is_tuesday(datetime(2014, 9, 25)), "should return false if the given date is not a Friday")
+
+    def test_is_tuesday_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_tuesday("2014-09-26")  # type: ignore

--- a/pydate/is_tuesday/test.py
+++ b/pydate/is_tuesday/test.py
@@ -8,7 +8,7 @@ class TestIsTuesday(unittest.TestCase):
     def test_is_tuesday(self) -> None:
         self.assertTrue(is_tuesday(datetime(2014, 9, 23)), "should return true if the given date is a Tuesday")
 
-    def test_is_not_tueday(self) -> None:
+    def test_is_not_tuesday(self) -> None:
         self.assertFalse(is_tuesday(datetime(2014, 9, 25)), "should return false if the given date is not a Tuesday")
 
     def test_is_tuesday_bad_date(self) -> None:

--- a/pydate/is_wednesday/__init__.py
+++ b/pydate/is_wednesday/__init__.py
@@ -1,0 +1,1 @@
+from .is_wednesday import is_wednesday

--- a/pydate/is_wednesday/is_wednesday.py
+++ b/pydate/is_wednesday/is_wednesday.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+
+def is_wednesday(date: datetime) -> bool:
+    """
+    Is the given date a Wednesday?
+
+    :param datetime date: datetime object
+    :return bool: True if the given date is a Wednesday, False otherwise
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    return date.weekday() == 1

--- a/pydate/is_wednesday/test.py
+++ b/pydate/is_wednesday/test.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from .is_wednesday import is_wednesday
 
 
-class TestIsFriday(unittest.TestCase):
+class TestIsWenesday(unittest.TestCase):
     def test_is_wednesday(self) -> None:
         self.assertTrue(is_wednesday(datetime(2014, 9, 24)), "should return true if the given date is a Wednesday")
 

--- a/pydate/is_wednesday/test.py
+++ b/pydate/is_wednesday/test.py
@@ -6,7 +6,7 @@ from .is_wednesday import is_wednesday
 
 class TestIsWenesday(unittest.TestCase):
     def test_is_wednesday(self) -> None:
-        self.assertTrue(is_wednesday(datetime(2014, 9, 24)), "should return true if the given date is a Wednesday")
+        self.assertTrue(is_wednesday(datetime(2014, 9, 23)), "should return true if the given date is a Wednesday")
 
     def test_is_not_wednesday(self) -> None:
         self.assertFalse(is_wednesday(datetime(2014, 9, 25)), "should return false if the given date is not a Wednesday")

--- a/pydate/is_wednesday/test.py
+++ b/pydate/is_wednesday/test.py
@@ -1,0 +1,16 @@
+import unittest
+from datetime import datetime
+
+from .is_wednesday import is_wednesday
+
+
+class TestIsFriday(unittest.TestCase):
+    def test_is_wednesday(self) -> None:
+        self.assertTrue(is_wednesday(datetime(2014, 9, 24)), "should return true if the given date is a Wednesday")
+
+    def test_is_not_wednesday(self) -> None:
+        self.assertFalse(is_wednesday(datetime(2014, 9, 25)), "should return false if the given date is not a Wednesday")
+
+    def test_is_wednesday_bad_date(self) -> None:
+        with self.assertRaises(TypeError):
+            is_wednesday("2014-09-26")  # type: ignore

--- a/pydate/to_naive/__init__.py
+++ b/pydate/to_naive/__init__.py
@@ -1,0 +1,1 @@
+from .to_naive import to_naive

--- a/pydate/to_naive/test.py
+++ b/pydate/to_naive/test.py
@@ -1,0 +1,21 @@
+import unittest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from .to_naive import to_naive
+
+
+class TestToNaive(unittest.TestCase):
+    def test_to_naive(self) -> None:
+        self.assertEqual(
+            to_naive(datetime(2014, 9, 25, 12, 30, 45, tzinfo=ZoneInfo("America/New_York"))),
+            datetime(2014, 9, 25, 16, 30, 45),
+            "should return a naive date",
+        )
+
+        # account for dst change
+        self.assertEqual(
+            to_naive(datetime(2014, 2, 25, 12, 30, 45, tzinfo=ZoneInfo("America/New_York"))),
+            datetime(2014, 2, 25, 17, 30, 45),
+            "should return a naive date",
+        )

--- a/pydate/to_naive/to_naive.py
+++ b/pydate/to_naive/to_naive.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+utc = ZoneInfo("UTC")
+
+
+def to_naive(date: datetime) -> datetime:
+    """
+    Convert a datetime object to a naive datetime object.
+
+    :param datetime date: datetime object (potentially aware)
+    :return datetime: naive datetime object
+    """
+    if not isinstance(date, datetime):
+        raise TypeError("date must be an instance of datetime")
+
+    if date.tzinfo is None:
+        return date
+
+    # convert to utc and remove tzinfo
+    return date.astimezone(utc).replace(tzinfo=None)

--- a/pydate/types.py
+++ b/pydate/types.py
@@ -1,0 +1,4 @@
+from decimal import Decimal
+from typing import TypeVar
+
+Timestamp = TypeVar("Timestamp", int, float, Decimal)

--- a/scripts/create_module.py
+++ b/scripts/create_module.py
@@ -1,3 +1,7 @@
+def snake_to_camel(name: str) -> str:
+    return "".join([i.capitalize() for i in name.split("_")])
+
+
 def main(name: str) -> None:
     # create a directory for the module
     # create a __init__.py file
@@ -28,7 +32,7 @@ import unittest
 from datetime import datetime
 from .{name} import {name}
 
-class Test{name}(unittest.TestCase):
+class Test{snake_to_camel(name)}(unittest.TestCase):
     def test_{name}(self) -> None:
         pass
 """

--- a/scripts/update_readme_diff.py
+++ b/scripts/update_readme_diff.py
@@ -5,29 +5,31 @@ def camel_to_snake(name):
     s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
 
+
 def main(methods: list[str]):
     """
     update the README.md file with the methods that are implemented in pydate-fns
     """
     import os
     import re
+
     os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "pydate"))
     # print list all directories in current directory
     pydate_methods = [i for i in os.listdir() if os.path.isdir(i)]
-    
+
     os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
     # print a text table with 3 columns, left aligned, 30 chars wide: method, pydate, date-fns
-    table = ["<!-- methods -->", "method", "---"]
+    table = ["<!-- methods -->", "", "### method", "", "---", ""]
     for method in sorted(methods):
         table.append(f"- [{'x' if camel_to_snake(method) in pydate_methods else ' '}] {method}")
     table.append("<!-- /methods -->")
-    
+
     # update the README.md file
     with open("README.md", "r") as f:
         readme = f.read()
         updated = re.sub(r"<!-- methods -->.*<!-- /methods -->", "\n".join(table), readme, flags=re.DOTALL)
 
-    with open("README.md", "w") as f:    
+    with open("README.md", "w") as f:
         f.write(updated)
 
 
@@ -39,20 +41,19 @@ def scrape_date_fns():
     from bs4 import BeautifulSoup
 
     # Make a request to the URL
-    response = requests.get('https://github.com/date-fns/date-fns/tree/main/src')
-    
+    response = requests.get("https://github.com/date-fns/date-fns/tree/main/src")
+
     # Parse the HTML content
-    soup = BeautifulSoup(response.text, 'html.parser')
+    soup = BeautifulSoup(response.text, "html.parser")
 
     # Find all the directories on the page
-    directories = soup.select('span.css-truncate.css-truncate-target')
-    
+    directories = soup.select("span.css-truncate.css-truncate-target")
+
     # Extract the names of the directories
     names = {d.text for d in directories if not (d.text.startswith("\n") or d.text.startswith("_") or "." in d.text)}
     return names
 
 
-if __name__ == "__main__":    
+if __name__ == "__main__":
     scraped_methods = scrape_date_fns()
     local_methods = main(list(scraped_methods))
-    


### PR DESCRIPTION
in this PR i am aiming to add some of the easiest is_* methods in from date-fns. 
the reason i am not implementing the full set is because i have not yet come to a decision on whether i want to make all datetime objects aware or naive. 

originally i wanted to make them all naive because of "performance" and to limit 3rd party dependencies (pytz).

after some more thought that really is not the focus of this library, it is here for developer convenience above all else so i am leaning towards making all objects aware (as much as possible). 

additionally the new [ZoneInfo](https://docs.python.org/3/library/zoneinfo.html) first party support makes it so i don't need any external library support for time zone information. 

in the next set of work i will work on first introducing some date creation, and mutation methods so that future methods that depend on "current time" like `is_past`, `is_weekday` will be easier to implement and i wont have to come back and rewrite them.